### PR TITLE
Notes for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ php artisan:migrate
 php shield:generate
 ```
 
+## Notes for Windows users
+
+You might need to create a symlink to the storage manually. You can do so easily with the following command
+
+```bash
+php artisan storage:link
+```
+
 ## License
 
 Trov Installer is open-sourced software licensed under the [MIT license](LICENSE.md).


### PR DESCRIPTION
Added a note for windows users to create symlink to the storage directory. The Laravel installer does not do this automatically for Windows.